### PR TITLE
Add disabledWallets prop, hide UniSat by default

### DIFF
--- a/src/provider/WalletConnectProvider.tsx
+++ b/src/provider/WalletConnectProvider.tsx
@@ -15,12 +15,30 @@ import type {
 
 const AUTO_RECONNECT_RETRIES = 5;
 
+/**
+ * Default wallets to hide from the connect modal.
+ * UniSat is disabled by default because it does not support MLDSA signatures
+ * or full OPNet transaction signing. Developers can override this by passing
+ * an empty array (or a custom list) to the `disabledWallets` prop.
+ */
+const DEFAULT_DISABLED_WALLETS: SupportedWallets[] = [SupportedWallets.UNISAT];
+
 interface WalletConnectProviderProps {
     theme?: 'light' | 'dark' | 'moto';
     children: ReactNode;
+    /**
+     * Wallets to hide from the connect modal.
+     * Defaults to `[SupportedWallets.UNISAT]` since UniSat lacks MLDSA support.
+     * Pass `[]` to show all registered wallets.
+     */
+    disabledWallets?: SupportedWallets[];
 }
 
-const WalletConnectProvider: React.FC<WalletConnectProviderProps> = ({ theme, children }) => {
+const WalletConnectProvider: React.FC<WalletConnectProviderProps> = ({
+    theme,
+    children,
+    disabledWallets = DEFAULT_DISABLED_WALLETS,
+}) => {
     const [pageLoaded, setPageLoaded] = useState<boolean>(false);
     const [connectError, setConnectError] = useState<string | undefined>(undefined);
     const timeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -203,10 +221,14 @@ const WalletConnectProvider: React.FC<WalletConnectProviderProps> = ({ theme, ch
         [selectedWallet, setNetwork],
     );
 
+    const enabledWallets = useMemo(() => {
+        return supportedWallets.filter(
+            (wallet) => !disabledWallets.includes(wallet.name),
+        );
+    }, [supportedWallets, disabledWallets]);
+
     const allWallets = useMemo(() => {
-        //console.log("Refreshing all wallets");
-        return supportedWallets.map((wallet): WalletInformation => {
-            //console.log(" --> ", wallet.name, wallet.controller.isInstalled(), wallet.controller.isConnected());
+        return enabledWallets.map((wallet): WalletInformation => {
             return {
                 name: wallet.name,
                 icon: wallet.icon,
@@ -215,13 +237,12 @@ const WalletConnectProvider: React.FC<WalletConnectProviderProps> = ({ theme, ch
             };
         });
         // eslint-disable-next-line
-    }, [supportedWallets, network, pageLoaded]);
+    }, [enabledWallets, network, pageLoaded]);
 
     const availableWallets = useMemo(() => {
-        return supportedWallets.filter((wallet) => wallet.controller.isInstalled());
-        //return supportedWallets
+        return enabledWallets.filter((wallet) => wallet.controller.isInstalled());
         // eslint-disable-next-line
-    }, [supportedWallets, network, pageLoaded]);
+    }, [enabledWallets, network, pageLoaded]);
 
     useEffect(() => {
         const walletType = walletAddress ? WalletController.getWalletType() : null;
@@ -409,7 +430,7 @@ const WalletConnectProvider: React.FC<WalletConnectProviderProps> = ({ theme, ch
                                 <p>No wallets available</p>
                                 <p>Supporting the following wallets</p>
                                 <div className="wallet-list">
-                                    {supportedWallets.map((wallet) => (
+                                    {enabledWallets.map((wallet) => (
                                         <a
                                             href={`https://chromewebstore.google.com/search/${wallet.name}`}>
                                             {wallet.icon ? (


### PR DESCRIPTION
## Summary

UniSat does not support MLDSA signatures or full OPNet transaction signing. Instead of removing it entirely, this adds a configurable `disabledWallets` prop to `WalletConnectProvider`.

**Default behavior:** UniSat is hidden from the connect modal.
**Opt-in:** Pass `disabledWallets={[]}` to show all registered wallets.

## API

```tsx
// Default: UniSat hidden
<WalletConnectProvider theme="dark">

// Explicit: show all wallets including UniSat
<WalletConnectProvider theme="dark" disabledWallets={[]}>

// Custom: hide specific wallets
<WalletConnectProvider theme="dark" disabledWallets={[SupportedWallets.UNISAT]}>
```

## Changes

Single file change in `WalletConnectProvider.tsx`:
- Added `disabledWallets` prop (defaults to `[SupportedWallets.UNISAT]`)
- Filters `allWallets`, `availableWallets`, and the fallback list through the disabled filter
- All UniSat code remains intact for devs who want it

Supersedes #24 based on community feedback.